### PR TITLE
Change renovate config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@example/portfolio",
+	"name": "@jakobbouchard/portfolio",
 	"type": "module",
 	"version": "0.0.1",
 	"packageManager": "pnpm@8.6.5",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:js-app", ":preserveSemverRanges"],
-	"baseBranches": ["main"],
+	"extends": ["config:js-app"],
 	"timezone": "America/Montreal"
 }


### PR DESCRIPTION
Use the default `config:js-app` instead of preserving semantic versioning ranges.